### PR TITLE
Add quotation marks to fields in sqlite/query.inc

### DIFF
--- a/includes/database/sqlite/query.inc
+++ b/includes/database/sqlite/query.inc
@@ -40,11 +40,13 @@ class InsertQuery_sqlite extends InsertQuery {
 
     // If we're selecting from a SelectQuery, finish building the query and
     // pass it back, as any remaining options are irrelevant.
+    $common = $comments . 'INSERT INTO {' . $this->table . '} (' . '\'' . implode('\', \'', $this->insertFields) . '\'' . ') ';
+
     if (!empty($this->fromQuery)) {
-      return $comments . 'INSERT INTO {' . $this->table . '} (' . implode(', ', $this->insertFields) . ') ' . $this->fromQuery;
+      return  $common . $this->fromQuery;
     }
 
-    return $comments . 'INSERT INTO {' . $this->table . '} (' . implode(', ', $this->insertFields) . ') VALUES (' . implode(', ', $placeholders) . ')';
+    return $common . ' VALUES (' . implode(', ', $placeholders) . ')';
   }
 
 }


### PR DESCRIPTION
Surround names of colums in sqlite query to work with colum names that are keywords in sqlite (e.g. default).
