### PR TITLE
 Fix: Warning: strcmp() expects parameter 2 to be string

### DIFF
--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -2782,8 +2782,11 @@ function system_settings_form_submit($form, &$form_state) {
 function _system_sort_requirements($a, $b) {
   if (!isset($a['weight'])) {
     if (!isset($b['weight'])) {
-      if(is_array($a['title']) || is_array($b['title'])) return false;
-      return strcmp($a['title'], $b['title']);
+      if(is_array($a['title']) || is_array($b['title'])) { 
+        return false;
+      } else {
+        return strcmp($a['title'], $b['title']);
+      }
     }
     return -$b['weight'];
   }


### PR DESCRIPTION
 I have seen lots of developers complain about this. Its a simple fix. 
