### PR TITLE
Only display terms from selected vocabularies when using Entity Reference (Taxonomy Term) field

### DIFF
--- a/core/modules/taxonomy/src/Plugin/entity_reference/selection/TermSelection.php
+++ b/core/modules/taxonomy/src/Plugin/entity_reference/selection/TermSelection.php
@@ -60,7 +60,7 @@ class TermSelection extends SelectionBase {
     $options = array();
 
     $bundles = entity_get_bundles('taxonomy_term');
-    $bundle_names = !empty($this->instance['settings']['handler_settings']['target_bundles']) ? $this->instance['settings']['handler_settings']['target_bundles'] : array_keys($bundles);
+    $bundle_names = !empty($this->fieldDefinition->settings['handler_settings']['target_bundles']) ? $this->fieldDefinition->settings['handler_settings']['target_bundles'] : array_keys($bundles);
 
     foreach ($bundle_names as $bundle) {
       if ($vocabulary = entity_load('taxonomy_vocabulary', $bundle)) {


### PR DESCRIPTION
This patch will fix accessing field definition settings properly so that the settings do actually have an effect. This fixes a problem with taxonomy term entity reference fields, where the field will display all terms from all vocabularies on the form instead of just the vocabularies defined in field settings.
