### PR TITLE
bugfix: preventing permissions from being automatically enabled

### DIFF
--- a/modules/user/user.admin.inc
+++ b/modules/user/user.admin.inc
@@ -524,11 +524,14 @@ function user_admin_perm($form_state, $rid = NULL) {
   }
 
   // Compile role array:
-  // Add a comma at the end so when searching for a permission, we can
-  // always search for "$perm," to make sure we do not confuse
+  // Add a comma at the beginning and end so when searching for a permission,
+  // we can always search for ", $perm," to make sure we do not confuse
   // permissions that are substrings of each other.
+  // For two permissions: 'OneModule view' and 'Module view', if we remove
+  // remove the comma from the beginning, enabling the former will
+  // automatically enable the latter
   while ($role = db_fetch_object($result)) {
-    $role_permissions[$role->rid] = $role->perm .',';
+    $role_permissions[$role->rid] = ', '.$role->perm .',';
   }
 
   // Retrieve role names for columns.
@@ -550,7 +553,7 @@ function user_admin_perm($form_state, $rid = NULL) {
         $form['permission'][$perm] = array('#value' => t($perm));
         foreach ($role_names as $rid => $name) {
           // Builds arrays for checked boxes for each role
-          if (strpos($role_permissions[$rid], $perm .',') !== FALSE) {
+          if (strpos($role_permissions[$rid], ', '. $perm .',') !== FALSE) {
             $status[$rid][] = $perm;
           }
         }


### PR DESCRIPTION
when permissions fit in their entirety at the end of other permission,
enabling the latter will automatically enable the former.

For example: Assuming that we have the following permissions:
1) MyModule view
2) ThisIsMyModule view

If you head to admin/user/permissions and enable permission 2,
the next time the page loads (after saving the change), the form
will appear with both permission enabled. The way it was implemented,
there is no delimiter for the beginning of the permission.

This fix basically expanded the comparison to include the commas
before and after (the comma after was already in place) the enabled permissions.

The surprising bit is that there was a comment in the code justifying
why adding a comma would prevent the substring matching from working.

P.S.: drupal 5 is also affected by this bug.
P.S.: function user_access also used to be affected by this bug, but it was fix by chance during a change aiming some performance improvement (commit https://github.com/drupal/drupal/commit/0313d801085e7326a9d7f60133a5e7a25ef945cf)