### PR TITLE
Use basepath when determining request_path

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -2824,7 +2824,7 @@ function request_path() {
     // This request is either a clean URL, or 'index.php', or nonsense.
     // Extract the path from REQUEST_URI.
     $request_path = strtok($_SERVER['REQUEST_URI'], '?');
-    $base_path_len = strlen(rtrim(dirname($_SERVER['SCRIPT_NAME']), '\/'));
+    $base_path_len = strlen($GLOBALS['base_path']);
     // Unescape and strip $base_path prefix, leaving q without a leading slash.
     $path = substr(urldecode($request_path), $base_path_len + 1);
     // If the path equals the script filename, either because 'index.php' was


### PR DESCRIPTION
This fixes an issue with running drupal at `public_html/drupal/` but serving it at `example.com/`. Without this change, the result of `request_path` for `example.com/oops/this_gets_cut` is `is_gets_cut`.