### PR TITLE
Add DRUPAL_ROOT constant to core.services.yml relative path

### DIFF
--- a/core/lib/Drupal/Core/DrupalKernel.php
+++ b/core/lib/Drupal/Core/DrupalKernel.php
@@ -513,7 +513,7 @@ class DrupalKernel implements DrupalKernelInterface, TerminableInterface {
       'app' => array(),
       'site' => array(),
     );
-    $this->serviceYamls['app']['core'] = 'core/core.services.yml';
+    $this->serviceYamls['app']['core'] = DRUPAL_ROOT . '/core/core.services.yml';
     $this->serviceProviderClasses['app']['core'] = 'Drupal\Core\CoreServiceProvider';
 
     // Retrieve enabled modules and register their namespaces.


### PR DESCRIPTION
The core.services.yml file is loaded with a relative path, it works fine when I load my drupal site but when I use it with composer it gives me the following error:

```bash
PHP Fatal error:  Uncaught exception 'Symfony\Component\DependencyInjection\Exception\InvalidArgumentException' with message 'The service file "core/core.services.yml" is not valid.'
```