### PR TITLE
Added absolute path to core.services.yml

### DIFF
--- a/core/lib/Drupal/Core/DrupalKernel.php
+++ b/core/lib/Drupal/Core/DrupalKernel.php
@@ -575,7 +575,7 @@ class DrupalKernel implements DrupalKernelInterface, TerminableInterface {
       'app' => array(),
       'site' => array(),
     );
-    $this->serviceYamls['app']['core'] = 'core/core.services.yml';
+    $this->serviceYamls['app']['core'] = $this->root . '/core/core.services.yml';
     $this->serviceProviderClasses['app']['core'] = 'Drupal\Core\CoreServiceProvider';
 
     // Retrieve enabled modules and register their namespaces.


### PR DESCRIPTION
It's needed when I try assign {root}/web/index.php instead  {root}/index.php like symfony application.