### PR TITLE
correctly unset diff attribute to correctly mark binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -45,17 +45,17 @@
 # Define binary file attributes.
 # - Do not treat them as text.
 # - Include binary diff in patches instead of "binary files differ."
-*.eot     -text diff
-*.exe     -text diff
-*.gif     -text diff
-*.gz      -text diff
-*.ico     -text diff
-*.jpeg    -text diff
-*.jpg     -text diff
-*.otf     -text diff
-*.phar    -text diff
-*.png     -text diff
-*.svgz    -text diff
-*.ttf     -text diff
-*.woff    -text diff
-*.woff2   -text diff
+*.eot     -text -diff
+*.exe     -text -diff
+*.gif     -text -diff
+*.gz      -text -diff
+*.ico     -text -diff
+*.jpeg    -text -diff
+*.jpg     -text -diff
+*.otf     -text -diff
+*.phar    -text -diff
+*.png     -text -diff
+*.svgz    -text -diff
+*.ttf     -text -diff
+*.woff    -text -diff
+*.woff2   -text -diff


### PR DESCRIPTION
Current .gitattibutes are not correctly handling binary files. Diff attribute needs to be unset.