### PR TITLE
Create page for existing fields

### DIFF
--- a/core/lib/Drupal/Core/Field/FieldItemBase.php
+++ b/core/lib/Drupal/Core/Field/FieldItemBase.php
@@ -36,6 +36,22 @@ abstract class FieldItemBase extends Map implements FieldItemInterface {
   /**
    * {@inheritdoc}
    */
+  public static function storageSettingsSummary(FieldStorageDefinitionInterface $field_definition): array {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function fieldSettingsSummary(FieldDefinitionInterface $field_definition): array {
+    $definition = \Drupal::service('plugin.manager.field.field_type')
+      ->getDefinition($field_definition->getType())['label'];
+    return [['#markup' => $definition, '#weight' => -10]];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public static function mainPropertyName() {
     return 'value';
   }

--- a/core/lib/Drupal/Core/Field/FieldItemInterface.php
+++ b/core/lib/Drupal/Core/Field/FieldItemInterface.php
@@ -263,6 +263,28 @@ interface FieldItemInterface extends ComplexDataInterface {
   public static function defaultFieldSettings();
 
   /**
+   * Returns a short summary of the field's storage-level settings.
+   *
+   * @param \Drupal\Core\Field\FieldStorageDefinitionInterface $field_definition
+   *   The field storage definition.
+   *
+   * @return array
+   *   A renderable array summarizing storage-level settings.
+   */
+  public static function storageSettingsSummary(FieldStorageDefinitionInterface $field_definition): array;
+
+  /**
+   * Returns a short summary of the field's field-level settings.
+   *
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The field entity.
+   *
+   * @return array
+   *   A renderable array summarizing the field-level settings.
+   */
+  public static function fieldSettingsSummary(FieldDefinitionInterface $field_definition): array;
+
+  /**
    * Returns a settings array that can be stored as a configuration value.
    *
    * For all use cases where field settings are stored and managed as

--- a/core/lib/Drupal/Core/Field/FieldTypePluginManager.php
+++ b/core/lib/Drupal/Core/Field/FieldTypePluginManager.php
@@ -124,6 +124,30 @@ class FieldTypePluginManager extends DefaultPluginManager implements FieldTypePl
   /**
    * {@inheritdoc}
    */
+  public function getStorageSettingsSummary(FieldStorageDefinitionInterface $field_definition) {
+    $plugin_definition = $this->getDefinition($field_definition->getType(), FALSE);
+    if (!empty($plugin_definition['class'])) {
+      $plugin_class = DefaultFactory::getPluginClass($field_definition->getType(), $plugin_definition);
+      return $plugin_class::storageSettingsSummary($field_definition);
+    }
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFieldSettingsSummary(FieldDefinitionInterface $field_definition) {
+    $plugin_definition = $this->getDefinition($field_definition->getType(), FALSE);
+    if (!empty($plugin_definition['class'])) {
+      $plugin_class = DefaultFactory::getPluginClass($field_definition->getType(), $plugin_definition);
+      return $plugin_class::fieldSettingsSummary($field_definition);
+    }
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getUiDefinitions() {
     $definitions = $this->getDefinitions();
 

--- a/core/lib/Drupal/Core/Field/FieldTypePluginManagerInterface.php
+++ b/core/lib/Drupal/Core/Field/FieldTypePluginManagerInterface.php
@@ -77,6 +77,32 @@ interface FieldTypePluginManagerInterface extends PluginManagerInterface, Catego
   public function getDefaultStorageSettings($type);
 
   /**
+   * Returns the summary of storage-level settings for a field type.
+   *
+   * @param \Drupal\Core\Field\FieldStorageDefinitionInterface $field_storage
+   *   The field storage definition.
+   *
+   * @return array
+   *   A renderable array for the field's storage-level settings summary, as
+   *   provided by the plugin definition, or an empty array if type or summary
+   *   is undefined.
+   */
+  public function getStorageSettingsSummary(FieldStorageDefinitionInterface $field_storage);
+
+  /**
+   * Returns the summary of field-level settings for a field type.
+   *
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The field entity.
+   *
+   * @return array
+   *   A renderable array for The field's field-level settings summary, as
+   *   provided by the plugin definition, or an empty array if type or summary
+   *   is undefined.
+   */
+  public function getFieldSettingsSummary(FieldDefinitionInterface $field_definition);
+
+  /**
    * Gets the definition of all field types that can be added via UI.
    *
    * @return array

--- a/core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php
+++ b/core/lib/Drupal/Core/Field/Plugin/Field/FieldType/EntityReferenceItem.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Core\Field\Plugin\Field\FieldType;
 
+use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\ContentEntityStorageInterface;
@@ -108,6 +109,49 @@ class EntityReferenceItem extends FieldItemBase implements OptionsProviderInterf
       ->addConstraint('EntityType', $settings['target_type']);
 
     return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function storageSettingsSummary(FieldStorageDefinitionInterface $field_definition): array {
+    $summary = parent::storageSettingsSummary($field_definition);
+    $target_type = $field_definition->getSetting('target_type');
+    $target_type_info = \Drupal::entityTypeManager()->getDefinition($target_type);
+    if (!empty($target_type_info)) {
+      $summary[] = t('Reference type: @entity_type', [
+        '@entity_type' => $target_type_info->getLabel(),
+      ]);
+    }
+    return $summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function fieldSettingsSummary(FieldDefinitionInterface $field_definition): array {
+    $summary = parent::fieldSettingsSummary($field_definition);
+    $target_type = $field_definition->getFieldStorageDefinition()->getSetting('target_type');
+    $handler_settings = $field_definition->getSetting('handler_settings');
+
+    if (!isset($handler_settings['target_bundles'])) {
+      return $summary;
+    }
+
+    /** @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_bundle_information */
+    $entity_bundle_information = \Drupal::service('entity_type.bundle.info');
+    $bundle_info = $entity_bundle_information->getBundleInfo($target_type);
+    $bundles = array_map(fn($bundle) => $bundle_info[$bundle]['label'], $handler_settings['target_bundles']);
+    $bundle_label = \Drupal::entityTypeManager()->getDefinition($target_type)->getBundleLabel();
+
+    if (!empty($bundles)) {
+      $summary[] = new FormattableMarkup('@bundle: @entity_type', [
+        '@bundle' => $bundle_label ?: new TranslatableMarkup('Bundle'),
+        '@entity_type' => implode(', ', $bundles),
+      ]);
+    }
+
+    return $summary;
   }
 
   /**

--- a/core/modules/field_ui/css/field_ui.admin.css
+++ b/core/modules/field_ui/css/field_ui.admin.css
@@ -10,6 +10,17 @@
 .field-ui-overview .region-message td {
   font-style: italic;
 }
+.field-settings-summary-cell > .item-list > ul > li,
+.storage-settings-summary-cell > .item-list > ul > li {
+  margin: 0;
+  list-style-type: none;
+}
+.field-settings-summary-cell > .item-list > ul > li {
+  font-size: 0.9em;
+}
+.field-settings-summary-cell > .item-list > ul > li:first-child {
+  font-size: 1em;
+}
 
 /* 'Manage form display' and 'Manage display' overview */
 .field-ui-overview .field-plugin-summary-cell {

--- a/core/modules/field_ui/src/FieldStorageConfigListBuilder.php
+++ b/core/modules/field_ui/src/FieldStorageConfigListBuilder.php
@@ -84,6 +84,15 @@ class FieldStorageConfigListBuilder extends ConfigEntityListBuilder {
   /**
    * {@inheritdoc}
    */
+  public function render() {
+    $build = parent::render();
+    $build['#attached']['library'][] = 'field_ui/drupal.field_ui';
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function buildHeader() {
     $header['id'] = $this->t('Field name');
     $header['entity_type'] = $this->t('Entity type');
@@ -92,6 +101,7 @@ class FieldStorageConfigListBuilder extends ConfigEntityListBuilder {
       'class' => [RESPONSIVE_PRIORITY_MEDIUM],
     ];
     $header['usage'] = $this->t('Used in');
+    $header['settings_summary'] = $this->t('Summary');
     return $header;
   }
 
@@ -127,6 +137,14 @@ class FieldStorageConfigListBuilder extends ConfigEntityListBuilder {
       '#theme' => 'item_list',
       '#items' => $usage,
       '#context' => ['list_style' => 'comma-list'],
+    ];
+    $summary = $this->fieldTypeManager->getStorageSettingsSummary($field_storage);
+    $row['data']['settings_summary'] = empty($summary) ? '' : [
+      'data' => [
+        '#theme' => 'item_list',
+        '#items' => $summary,
+      ],
+      'class' => ['storage-settings-summary-cell'],
     ];
     return $row;
   }

--- a/core/modules/field_ui/src/Form/FieldStorageAddForm.php
+++ b/core/modules/field_ui/src/Form/FieldStorageAddForm.php
@@ -9,10 +9,12 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldTypePluginManagerInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\field\FieldStorageConfigInterface;
 use Drupal\field_ui\FieldUI;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Component\Serialization\Json;
 
 /**
  * Provides a form for the "field storage" add page.
@@ -152,12 +154,18 @@ class FieldStorageAddForm extends FormBase {
         '#type' => 'item',
         '#markup' => $this->t('or'),
       ];
+
+      $entity_type = $this->entityTypeManager->getDefinition($this->entityTypeId);
+
       $form['add']['existing_storage_name'] = [
-        '#type' => 'select',
-        '#title' => $this->t('Re-use an existing field'),
-        '#options' => $existing_field_storage_options,
-        '#empty_option' => $this->t('- Select an existing field -'),
-      ];
+          '#type' => 'link',
+          '#title' => 'Re-use an existing field',
+          '#value' => $this->t('Re-use an existing field'),
+          '#url' => Url::fromRoute("field_ui.field_storage_config_add_{$this->entityTypeId}.reuse", FieldUI::getRouteBundleParameter($entity_type, $this->bundle)),
+          '#attributes' => [
+            'class' => ['button', 'button--action', 'button-primary'],
+            ]
+        ];
 
       $form['#attached']['drupalSettings']['existingFieldLabels'] = $this->getExistingFieldLabels(array_keys($existing_field_storage_options));
     }

--- a/core/modules/field_ui/src/Form/FieldStorageReuseForm.php
+++ b/core/modules/field_ui/src/Form/FieldStorageReuseForm.php
@@ -1,0 +1,404 @@
+<?php
+
+
+namespace Drupal\field_ui\Form;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\FieldTypePluginManagerInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\FieldStorageConfigInterface;
+use Drupal\field_ui\FieldUI;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Component\Serialization\Json;
+
+/**
+ * Provides a form for the "field storage" add page.
+ *
+ * @internal
+ */
+class FieldStorageReuseForm extends FormBase {
+
+  /**
+   * The name of the entity type.
+   *
+   * @var string
+   */
+  protected $entityTypeId;
+
+  /**
+   * The entity bundle.
+   *
+   * @var string
+   */
+  protected $bundle;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The entity display repository.
+   *
+   * @var \Drupal\Core\Entity\EntityDisplayRepositoryInterface
+   */
+  protected $entityDisplayRepository;
+
+  /**
+   * The field type plugin manager.
+   *
+   * @var \Drupal\Core\Field\FieldTypePluginManagerInterface
+   */
+  protected $fieldTypePluginManager;
+
+  /**
+   * The configuration factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a new FieldStorageAddForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Field\FieldTypePluginManagerInterface $field_type_plugin_manager
+   *   The field type plugin manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface|null $entity_field_manager
+   *   (optional) The entity field manager.
+   * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
+   *   (optional) The entity display repository.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, FieldTypePluginManagerInterface $field_type_plugin_manager, ConfigFactoryInterface $config_factory, EntityFieldManagerInterface $entity_field_manager = NULL, EntityDisplayRepositoryInterface $entity_display_repository = NULL)
+  {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->fieldTypePluginManager = $field_type_plugin_manager;
+    $this->configFactory = $config_factory;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->entityDisplayRepository = $entity_display_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId()
+  {
+    return 'field_ui_field_storage_reuse_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container)
+  {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('plugin.manager.field.field_type'),
+      $container->get('config.factory'),
+      $container->get('entity_field.manager'),
+      $container->get('entity_display.repository')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL, $bundle = NULL)
+  {
+    if (!$form_state->get('entity_type_id')) {
+      $form_state->set('entity_type_id', $entity_type_id);
+    }
+    if (!$form_state->get('bundle')) {
+      $form_state->set('bundle', $bundle);
+    }
+
+    $this->entityTypeId = $form_state->get('entity_type_id');
+    $this->bundle = $form_state->get('bundle');
+
+    // Gather valid field types.
+    $field_type_options = [];
+    foreach ($this->fieldTypePluginManager->getGroupedDefinitions($this->fieldTypePluginManager->getUiDefinitions()) as $category => $field_types) {
+      foreach ($field_types as $name => $field_type) {
+        $field_type_options[$category][$name] = $field_type['label'];
+      }
+    }
+
+    $form['text'] = [
+      '#type' => 'inline_template',
+      '#template' => "You can re-use a field from other sub-types of the same entity type. Re-using a field creates another usage of the same field storage.
+      \nLorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsumLorem ipsumLorem ipsum",
+    ];
+
+    $form['search'] = [
+      '#type' => 'search',
+      '#placeholder' => $this->t('Search'),
+    ];
+
+    $form['add'] = [
+      '#type' => 'container',
+      '#attributes' => ['class' => ['form--inline', 'clearfix']],
+    ];
+
+
+    foreach ($this->getExistingFieldStorageOptions() as $field) {
+      echo($field);
+      $row = [
+        'field' => [
+          'data' => [
+          ],
+        ],
+        'field_type' => [
+          'data' => [
+            '#theme' => 'username',
+          ],
+        ],
+        'settings' => [
+          'class' => ['comments'],
+        ],
+        'content_type' => [
+          'class' => ['comments'],
+        ],
+        'operations' => [
+          'data' => [
+            '#type' => 'button',
+            '#value' => $this->t('Reuse'),
+          ],
+        ],
+      ];
+
+      $rows[] = $row;
+    }
+
+
+    // Sort rows by field name.
+    ksort($rows);
+    $form['add']['table'] = [
+      '#type' => 'table',
+      '#rows' => $rows,
+      '#header' => array($this->t('Field'), $this->t('Field Type'), $this->t('Settings'), $this->t('Content Type'), $this->t('Operations')),
+    ];
+
+
+    $existing_field_storage_options = $this->getExistingFieldStorageOptions();
+      $form['add']['separator'] = [
+        '#type' => 'item',
+        '#markup' => $this->t('or'),
+      ];
+      $form['add']['existing_storage_name'] = [
+        '#type' => 'select',
+        '#title' => $this->t('Re-use an existing field'),
+        '#options' => $existing_field_storage_options,
+        '#empty_option' => $this->t('- Select an existing field -'),
+      ];
+
+      $form['#attached']['drupalSettings']['existingFieldLabels'] = $this->getExistingFieldLabels(array_keys($existing_field_storage_options));
+
+
+    // Place the 'translatable' property as an explicit value so that contrib
+    // modules can form_alter() the value for newly created fields. By default
+    // we create field storage as translatable so it will be possible to enable
+    // translation at field level.
+    $form['translatable'] = [
+      '#type' => 'value',
+      '#value' => TRUE,
+    ];
+
+    $form['#attached']['library'][] = 'field_ui/drupal.field_ui';
+
+    return $form;
+  }
+  /**
+   * Validates the 're-use existing field' case.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @see \Drupal\field_ui\Form\FieldStorageAddForm::validateForm()
+   */
+  protected function validateAddExisting(array $form, FormStateInterface $form_state)
+  {
+    if ($form_state->getValue('existing_storage_name')) {
+      // Missing label.
+      if (!$form_state->getValue('existing_storage_label')) {
+        $form_state->setErrorByName('existing_storage_label', $this->t('Re-use existing field: you need to provide a label.'));
+      }
+    }
+  }
+
+  /**
+   * Configures the field for the default form mode.
+   *
+   * @param string $field_name
+   *   The field name.
+   * @param string|null $widget_id
+   *   (optional) The plugin ID of the widget. Defaults to NULL.
+   * @param array $widget_settings
+   *   (optional) An array of widget settings. Defaults to an empty array.
+   */
+  protected function configureEntityFormDisplay($field_name, $widget_id = NULL, array $widget_settings = [])
+  {
+    $options = [];
+    if ($widget_id) {
+      $options['type'] = $widget_id;
+      if (!empty($widget_settings)) {
+        $options['settings'] = $widget_settings;
+      }
+    }
+    // Make sure the field is displayed in the 'default' form mode (using
+    // default widget and settings). It stays hidden for other form modes
+    // until it is explicitly configured.
+    $this->entityDisplayRepository->getFormDisplay($this->entityTypeId, $this->bundle, 'default')
+      ->setComponent($field_name, $options)
+      ->save();
+  }
+
+  /**
+   * Configures the field for the default view mode.
+   *
+   * @param string $field_name
+   *   The field name.
+   * @param string|null $formatter_id
+   *   (optional) The plugin ID of the formatter. Defaults to NULL.
+   * @param array $formatter_settings
+   *   (optional) An array of formatter settings. Defaults to an empty array.
+   */
+  protected function configureEntityViewDisplay($field_name, $formatter_id = NULL, array $formatter_settings = [])
+  {
+    $options = [];
+    if ($formatter_id) {
+      $options['type'] = $formatter_id;
+      if (!empty($formatter_settings)) {
+        $options['settings'] = $formatter_settings;
+      }
+    }
+    // Make sure the field is displayed in the 'default' view mode (using
+    // default formatter and settings). It stays hidden for other view
+    // modes until it is explicitly configured.
+    $this->entityDisplayRepository->getViewDisplay($this->entityTypeId, $this->bundle)
+      ->setComponent($field_name, $options)
+      ->save();
+  }
+
+  /**
+   * Returns an array of existing field storages that can be added to a bundle.
+   *
+   * @return array
+   *   An array of existing field storages keyed by name.
+   */
+  protected function getExistingFieldStorageOptions()
+  {
+    $options = [];
+    // Load the field_storages and build the list of options.
+    $field_types = $this->fieldTypePluginManager->getDefinitions();
+    foreach ($this->entityFieldManager->getFieldStorageDefinitions($this->entityTypeId) as $field_name => $field_storage) {
+      // Do not show:
+      // - non-configurable field storages,
+      // - locked field storages,
+      // - field storages that should not be added via user interface,
+      // - field storages that already have a field in the bundle.
+      $field_type = $field_storage->getType();
+      if ($field_storage instanceof FieldStorageConfigInterface
+        && !$field_storage->isLocked()
+        && empty($field_types[$field_type]['no_ui'])
+        && !in_array($this->bundle, $field_storage->getBundles(), TRUE)) {
+        $options[$field_name] = $this->t('@type: @field', [
+          '@type' => $field_types[$field_type]['label'],
+          '@field' => $field_name,
+        ]);
+      }
+    }
+    asort($options);
+
+    return $options;
+  }
+
+  /**
+   * Gets the human-readable labels for the given field storage names.
+   *
+   * Since not all field storages are required to have a field, we can only
+   * provide the field labels on a best-effort basis (e.g. the label of a field
+   * storage without any field attached to a bundle will be the field name).
+   *
+   * @param array $field_names
+   *   An array of field names.
+   *
+   * @return array
+   *   An array of field labels keyed by field name.
+   */
+  protected function getExistingFieldLabels(array $field_names)
+  {
+    // Get all the fields corresponding to the given field storage names and
+    // this entity type.
+    $field_ids = $this->entityTypeManager->getStorage('field_config')->getQuery()
+      ->condition('entity_type', $this->entityTypeId)
+      ->condition('field_name', $field_names)
+      ->execute();
+    $fields = $this->entityTypeManager->getStorage('field_config')->loadMultiple($field_ids);
+
+    // Go through all the fields and use the label of the first encounter.
+    $labels = [];
+    foreach ($fields as $field) {
+      if (!isset($labels[$field->getName()])) {
+        $labels[$field->getName()] = $field->label();
+      }
+    }
+
+    // For field storages without any fields attached to a bundle, the default
+    // label is the field name.
+    $labels += array_combine($field_names, $field_names);
+
+    return $labels;
+  }
+
+  /**
+   * Checks if a field machine name is taken.
+   *
+   * @param string $value
+   *   The machine name, not prefixed.
+   * @param array $element
+   *   An array containing the structure of the 'field_name' element.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return bool
+   *   Whether or not the field machine name is taken.
+   */
+  public function fieldNameExists($value, $element, FormStateInterface $form_state)
+  {
+    // Don't validate the case when an existing field has been selected.
+    if ($form_state->getValue('existing_storage_name')) {
+      return FALSE;
+    }
+
+    // Add the field prefix.
+    $field_name = $this->configFactory->get('field_ui.settings')->get('field_prefix') . $value;
+
+    $field_storage_definitions = $this->entityFieldManager->getFieldStorageDefinitions($this->entityTypeId);
+    return isset($field_storage_definitions[$field_name]);
+  }
+
+  public function submitForm(array &$form, FormStateInterface $form_state)
+  {
+    // TODO: Implement submitForm() method.
+  }
+}

--- a/core/modules/field_ui/src/Routing/RouteSubscriber.php
+++ b/core/modules/field_ui/src/Routing/RouteSubscriber.php
@@ -110,6 +110,17 @@ class RouteSubscriber extends RouteSubscriberBase {
         $collection->add("field_ui.field_storage_config_add_$entity_type_id", $route);
 
         $route = new Route(
+          "$path/fields/add-field/reuse",
+          [
+            '_form' => '\Drupal\field_ui\Form\FieldStorageReuseForm',
+            '_title' => 'Re-use an existing field',
+          ] + $defaults,
+          ['_permission' => 'administer ' . $entity_type_id . ' fields'],
+          $options
+        );
+        $collection->add("field_ui.field_storage_config_add_$entity_type_id.reuse", $route);
+
+        $route = new Route(
           "$path/form-display",
           [
             '_entity_form' => 'entity_form_display.edit',

--- a/core/modules/field_ui/tests/src/Functional/ManageFieldsTest.php
+++ b/core/modules/field_ui/tests/src/Functional/ManageFieldsTest.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\field_ui\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 
+// cSpell:ignore downlander
+
 /**
  * Tests the Manage Display page of a fieldable entity type.
  *
@@ -38,8 +40,14 @@ class ManageFieldsTest extends BrowserTestBase {
       ->save();
   }
 
+  /**
+   * Tests drop button operations on the manage fields page.
+   */
   public function testFieldDropButtonOperations() {
+    $assert_session = $this->assertSession();
+
     $node_type = $this->drupalCreateContentType();
+    $bundle = $node_type->id();
 
     /** @var \Drupal\field\FieldStorageConfigInterface $storage */
     $storage = $this->container->get('entity_type.manager')
@@ -55,12 +63,55 @@ class ManageFieldsTest extends BrowserTestBase {
       ->getStorage('field_config')
       ->create([
         'field_storage' => $storage,
-        'bundle' => $node_type->id(),
+        'bundle' => $bundle,
       ])
       ->save();
 
-    $this->drupalGet('/admin/structure/types/manage/' . $node_type->id() . '/fields');
+    $this->drupalGet("/admin/structure/types/manage/{$bundle}/fields");
 
+    // Check that the summary element for the string field type exists and has
+    // the correct text (which comes from the FieldItemBase class).
+    $element = $assert_session->elementExists('css', '#highlander');
+    $summary = $assert_session->elementExists('css', '.field-settings-summary-cell > ul > li', $element);
+    $field_label = $this->container->get('plugin.manager.field.field_type')->getDefinitions()['string']['label'];
+    $this->assertEquals($field_label, $summary->getText());
+
+    // Add an entity reference field, and check that its summary is custom.
+    /** @var \Drupal\field\FieldStorageConfigInterface $storage */
+    $storage = $this->container->get('entity_type.manager')
+      ->getStorage('field_storage_config')
+      ->create([
+        'type' => 'entity_reference',
+        'field_name' => 'downlander',
+        'entity_type' => 'node',
+        'settings' => [
+          'target_type' => 'node',
+        ],
+      ]);
+    $storage->save();
+
+    $this->container->get('entity_type.manager')
+      ->getStorage('field_config')
+      ->create([
+        'field_storage' => $storage,
+        'bundle' => $bundle,
+        'entity_type' => 'node',
+        'settings' => [
+          'handler_settings' => [
+            'target_bundles' => [$bundle => $bundle],
+          ],
+        ],
+      ])
+      ->save();
+
+    $this->drupalGet("/admin/structure/types/manage/{$bundle}/fields");
+    $element = $assert_session->elementExists('css', '#downlander');
+    $summary = $assert_session->elementExists('css', '.field-settings-summary-cell > ul > li:nth-child(2)', $element);
+    $allowed_bundles = $assert_session->elementExists('css', '.field-settings-summary-cell > ul > li:nth-child(3)', $element);
+    $custom_summary_text = 'Reference type: Content';
+    $allowed_bundles_text = "Content type: $bundle";
+    $this->assertEquals($custom_summary_text, $summary->getText());
+    $this->assertEquals($allowed_bundles_text, $allowed_bundles->getText());
   }
 
 }

--- a/core/modules/system/tests/src/Functional/UpdateSystem/UpdatePathTestBaseFilledTest.php
+++ b/core/modules/system/tests/src/Functional/UpdateSystem/UpdatePathTestBaseFilledTest.php
@@ -32,6 +32,8 @@ class UpdatePathTestBaseFilledTest extends UpdatePathTestBaseTest {
    * Tests that the content and configuration were properly updated.
    */
   public function testUpdatedSite() {
+    $assert_session = $this->assertSession();
+
     $this->runUpdates();
 
     $spanish = \Drupal::languageManager()->getLanguage('es');
@@ -227,24 +229,24 @@ class UpdatePathTestBaseFilledTest extends UpdatePathTestBaseTest {
     $this->drupalGet('admin/structure/types/manage/test_content_type/fields');
 
     // Make sure fields are the right type.
-    $this->assertSession()->linkExists('Text (formatted, long, with summary)');
-    $this->assertSession()->linkExists('Boolean');
-    $this->assertSession()->linkExists('Comments');
-    $this->assertSession()->linkExists('Date');
-    $this->assertSession()->linkExists('Email');
-    $this->assertSession()->linkExists('Link');
-    $this->assertSession()->linkExists('List (float)');
-    $this->assertSession()->linkExists('Telephone number');
-    $this->assertSession()->linkExists('Entity reference');
-    $this->assertSession()->linkExists('File');
-    $this->assertSession()->linkExists('Image');
-    $this->assertSession()->linkExists('Text (plain, long)');
-    $this->assertSession()->linkExists('List (text)');
-    $this->assertSession()->linkExists('Text (formatted, long)');
-    $this->assertSession()->linkExists('Text (plain)');
-    $this->assertSession()->linkExists('List (integer)');
-    $this->assertSession()->linkExists('Number (integer)');
-    $this->assertSession()->linkExists('Number (float)');
+    $assert_session->elementContains('css', '#body', 'Text (formatted, long, with summary)');
+    $assert_session->elementContains('css', '#field-test-1', 'Boolean');
+    $assert_session->elementContains('css', '#field-test-2', 'Comments');
+    $assert_session->elementContains('css', '#field-test-3', 'Date');
+    $assert_session->elementContains('css', '#field-test-4', 'Email');
+    $assert_session->elementContains('css', '#field-test-5', 'Link');
+    $assert_session->elementContains('css', '#field-test-6', 'List (float)');
+    $assert_session->elementContains('css', '#field-test-7', 'Telephone number');
+    $assert_session->elementContains('css', '#field-test-8', 'Entity reference');
+    $assert_session->elementContains('css', '#field-test-9', 'File');
+    $assert_session->elementContains('css', '#field-test-10', 'Image');
+    $assert_session->elementContains('css', '#field-test-15', 'Text (plain, long)');
+    $assert_session->elementContains('css', '#field-test-16', 'List (text)');
+    $assert_session->elementContains('css', '#field-test-17', 'Text (formatted)');
+    $assert_session->elementContains('css', '#field-test-18', 'Text (formatted, long)');
+    $assert_session->elementContains('css', '#field-test-20', 'List (integer)');
+    $assert_session->elementContains('css', '#field-test-22', 'Number (float)');
+    $assert_session->elementContains('css', '#field-test-23', 'Number (integer)');
 
     // Make sure our form mode exists.
     $this->drupalGet('admin/structure/display-modes/form');

--- a/core/themes/claro/css/theme/field-ui.admin.css
+++ b/core/themes/claro/css/theme/field-ui.admin.css
@@ -80,3 +80,17 @@
 .field-plugin-settings-edit-form .plugin-name {
   font-weight: bold;
 }
+
+.field-settings-summary-cell > .item-list > ul > li,
+.storage-settings-summary-cell > .item-list > ul > li {
+  margin: 0;
+  list-style-type: none;
+}
+
+.field-settings-summary-cell > .item-list > ul > li {
+  font-size: 0.9em;
+}
+
+.field-settings-summary-cell > .item-list > ul > li:first-child {
+  font-size: 1em;
+}

--- a/core/themes/claro/css/theme/field-ui.admin.pcss.css
+++ b/core/themes/claro/css/theme/field-ui.admin.pcss.css
@@ -63,3 +63,15 @@
 .field-plugin-settings-edit-form .plugin-name {
   font-weight: bold;
 }
+
+.field-settings-summary-cell > .item-list > ul > li,
+.storage-settings-summary-cell > .item-list > ul > li {
+  margin: 0;
+  list-style-type: none;
+}
+.field-settings-summary-cell > .item-list > ul > li {
+  font-size: 0.9em;
+}
+.field-settings-summary-cell > .item-list > ul > li:first-child {
+  font-size: 1em;
+}

--- a/core/themes/stable9/css/field_ui/field_ui.admin.css
+++ b/core/themes/stable9/css/field_ui/field_ui.admin.css
@@ -10,6 +10,17 @@
 .field-ui-overview .region-message td {
   font-style: italic;
 }
+.field-settings-summary-cell > .item-list > ul > li,
+.storage-settings-summary-cell > .item-list > ul > li {
+  margin: 0;
+  list-style-type: none;
+}
+.field-settings-summary-cell > .item-list > ul > li {
+  font-size: 0.9em;
+}
+.field-settings-summary-cell > .item-list > ul > li:first-child {
+  font-size: 1em;
+}
 
 /* 'Manage form display' and 'Manage display' overview */
 .field-ui-overview .field-plugin-summary-cell {


### PR DESCRIPTION
This PR adds a button to the add fields page if there are existing fields and clicking that button opens up a new page `/drupal/admin/structure/types/manage/page/fields/add-field/reuse` that should look like this: 

![image](https://user-images.githubusercontent.com/35243020/220791925-15437afb-7c49-4f7a-975d-d451fed4f290.png)
