### PR TITLE
feat: Added Elestio as one-click deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ You can quickly extend Drupal's core feature set by installing any of its
 module ecosystem, you can often build most or all of what your project needs
 before writing a single line of code.
 
+## Self-Hosting Options
+
+### Elestio
+
+You can deploy Drupal on Elestio using one-click deployment.
+
+[![Deploy on Elestio](https://elest.io/images/logos/deploy-to-elestio-btn.png)](https://elest.io/open-source/drupal)
+
 ## Changelog
 
 Drupal keeps detailed [change records][changelog]. You can search Drupal's


### PR DESCRIPTION
Hey team,
I am Kaiwalya, Developer Advocate at Elestio. Elestio has been providing options of fully deploying and managing Drupal application as shown [here](https://elest.io/open-source/drupal). I think it would be a great idea if we can add it to official readme/documentation here.
🔔 In addition to this, if you are interested we provide partnership opportunities with tools we support by **revenue share** upon addition of this method in docs. I see we have a email thread about conversation already, If you would like me to bump it up, just shoot me an email at [kaiwalya@elest.io](mailto:kaiwalya@elest.io) :)